### PR TITLE
chore: some changes

### DIFF
--- a/crates/poirot-core/Cargo.toml
+++ b/crates/poirot-core/Cargo.toml
@@ -26,7 +26,8 @@ reth-interfaces = { git = "https://github.com/paradigmxyz/reth", package = "reth
 
 tokio = { version = "1.28.2", features = ["full"] }
 eyre = "0.6.8"
-
+tracing = "0.1.0"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
 
 # evm
 ethers = { version = "2.0.7",  features = ["ipc", "ws"] }

--- a/crates/poirot-core/src/main.rs
+++ b/crates/poirot-core/src/main.rs
@@ -1,11 +1,20 @@
 use poirot_core::TracingClient;
 use std::{env, error::Error, path::Path};
+use tracing::Subscriber;
+use tracing_subscriber::{
+    filter::Directive, prelude::*, registry::LookupSpan, EnvFilter, Layer, Registry,
+};
 
 // reth types
 use reth_primitives::BlockId;
 use reth_rpc_types::trace::geth::GethDebugTracingOptions;
 
 fn main() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_writer(std::io::stderr)
+        .try_init();
+
     // Create the runtime
     let runtime = tokio_runtime().expect("Failed to create runtime");
 


### PR DESCRIPTION
installs tracing

spawns the task executor, alternative you can also use the tokio task executor

now run with `RUST_LOG=trace` and it should print the panic info

I assume it has something to do with BeaconConsensus

I promise I will make this easier to setup and will add more docs